### PR TITLE
feat(map): Implement core Leaflet map setup and initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ show_warning_levels: true
 
 See [CONTEXT.md](CONTEXT.md) for development setup instructions.
 
+## Why Leaflet 1.9.4?
+
+This card uses **Leaflet 1.9.4** rather than the newer 2.0.0-alpha. Here's why:
+
+| Concern | Leaflet 1.9.4 | Leaflet 2.0.0-alpha |
+|---------|---------------|---------------------|
+| **Stability** | Production-ready | Alpha (expect bugs) |
+| **SRI Security** | Available | Not available |
+| **Plugin Ecosystem** | Full compatibility | Most plugins not updated |
+| **API Stability** | Stable | May change before release |
+
+**Leaflet 2.0 stable is targeted for November 2025.** We plan to migrate once:
+- The stable release is published
+- SRI hashes are available for CDN integrity verification
+- Core plugins we may need are updated
+
+If you're interested in tracking this, see the [Leaflet 2.0 discussion](https://github.com/Leaflet/Leaflet/discussions/9719).
+
 ## License
 
 MIT

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,28 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import eslintConfigPrettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
+  {
+    ignores: ["dist/**", "node_modules/**", "*.js", "*.mjs", "src/**/*.d.ts"],
+  }
+);

--- a/package.json
+++ b/package.json
@@ -27,13 +27,16 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write \"src/**/*.ts\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "pnpm run typecheck && pnpm run lint && pnpm run build"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.2",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.0",
+    "@types/leaflet": "^1.9.21",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",
@@ -41,9 +44,11 @@
     "prettier": "^3.4.0",
     "rollup": "^4.28.0",
     "tslib": "^2.8.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.51.0"
   },
   "dependencies": {
+    "custom-card-helpers": "^1.9.0",
     "home-assistant-js-websocket": "^9.4.0",
     "leaflet": "^1.9.4",
     "lit": "^3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      custom-card-helpers:
+        specifier: ^1.9.0
+        version: 1.9.0
       home-assistant-js-websocket:
         specifier: ^9.4.0
         version: 9.6.0
@@ -18,6 +21,9 @@ importers:
         specifier: ^3.2.0
         version: 3.3.2
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.2
       '@rollup/plugin-commonjs':
         specifier: ^28.0.0
         version: 28.0.9(rollup@4.54.0)
@@ -30,6 +36,9 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^12.1.0
         version: 12.3.0(rollup@4.54.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@types/leaflet':
+        specifier: ^1.9.21
+        version: 1.9.21
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
         version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
@@ -54,6 +63,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.51.0
+        version: 8.51.0(eslint@9.39.2)(typescript@5.9.3)
 
 packages:
 
@@ -95,6 +107,25 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@formatjs/ecma402-abstract@1.11.4':
+    resolution: {integrity: sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==}
+
+  '@formatjs/fast-memoize@1.2.1':
+    resolution: {integrity: sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==}
+
+  '@formatjs/icu-messageformat-parser@2.1.0':
+    resolution: {integrity: sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==}
+
+  '@formatjs/icu-skeleton-parser@1.3.6':
+    resolution: {integrity: sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==}
+
+  '@formatjs/intl-localematcher@0.2.25':
+    resolution: {integrity: sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==}
+
+  '@formatjs/intl-utils@3.8.4':
+    resolution: {integrity: sha512-j5C6NyfKevIxsfLK8KwO1C0vvP7k1+h4A9cFpc+cr6mEwCc1sPkr17dzh0Ke6k9U5pQccAQoXdcNBl3IYa4+ZQ==}
+    deprecated: the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -129,6 +160,9 @@ packages:
 
   '@lit-labs/ssr-dom-shim@1.5.0':
     resolution: {integrity: sha512-HLomZXMmrCFHSRKESF5vklAKsDY7/fsT/ZhqCu3V0UoW/Qbv8wxmO4W9bx4KnCCF2Zak4yuk+AGraK/bPmI4kA==}
+
+  '@lit/reactive-element@1.6.3':
+    resolution: {integrity: sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==}
 
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
@@ -295,8 +329,14 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/leaflet@1.9.21':
+    resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -423,6 +463,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  custom-card-helpers@1.9.0:
+    resolution: {integrity: sha512-5IW4OXq3MiiCqDvqeu+MYsM1NmntKW1WfJhyJFsdP2tbzqEI4BOnqRz2qzdp08lE4QLVhYfRLwe0WAqgQVNeFg==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -438,6 +481,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  emojis-list@3.0.0:
+    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
+    engines: {node: '>= 4'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -551,6 +598,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  home-assistant-js-websocket@6.1.1:
+    resolution: {integrity: sha512-TnZFzF4mn5F/v0XKUTK2GMQXrn/+eQpgaSDSELl6U0HSwSbFwRhGWLz330YT+hiKMspDflamsye//RPL+zwhDw==}
+
   home-assistant-js-websocket@9.6.0:
     resolution: {integrity: sha512-TK8HWW6UjCsUdjIBQRB2sBbEya0VniOBFqFjgqSznJiB7YriNgN8jghyThxOkgxwrnt2eN6oWoZMCTSp1o7H+w==}
 
@@ -569,6 +619,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  intl-messageformat@9.13.0:
+    resolution: {integrity: sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -614,11 +667,20 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lit-element@3.3.3:
+    resolution: {integrity: sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==}
+
   lit-element@4.2.2:
     resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
 
+  lit-html@2.8.0:
+    resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
+
   lit-html@3.3.2:
     resolution: {integrity: sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==}
+
+  lit@2.8.0:
+    resolution: {integrity: sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==}
 
   lit@3.3.2:
     resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
@@ -702,6 +764,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  rollup@2.79.2:
+    resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   rollup@4.54.0:
     resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -740,6 +807,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  superstruct@0.15.5:
+    resolution: {integrity: sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -769,6 +839,18 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.51.0:
+    resolution: {integrity: sha512-jh8ZuM5oEh2PSdyQG9YAEM1TCGuWenLSuSUhf/irbVUNW9O5FhbFVONviN2TgMTBnUmyHv7E56rYnfLZK6TkiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -839,6 +921,34 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@formatjs/ecma402-abstract@1.11.4':
+    dependencies:
+      '@formatjs/intl-localematcher': 0.2.25
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.1.0':
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.11.4
+      '@formatjs/icu-skeleton-parser': 1.3.6
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.3.6':
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.11.4
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.2.25':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-utils@3.8.4':
+    dependencies:
+      emojis-list: 3.0.0
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -870,6 +980,10 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@lit-labs/ssr-dom-shim@1.5.0': {}
+
+  '@lit/reactive-element@1.6.3':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.0
 
   '@lit/reactive-element@2.1.2':
     dependencies:
@@ -990,7 +1104,13 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/leaflet@1.9.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/resolve@1.20.2': {}
 
@@ -1144,6 +1264,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  custom-card-helpers@1.9.0:
+    dependencies:
+      '@formatjs/intl-utils': 3.8.4
+      home-assistant-js-websocket: 6.1.1
+      intl-messageformat: 9.13.0
+      lit: 2.8.0
+      rollup: 2.79.2
+      superstruct: 0.15.5
+      typescript: 4.9.5
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -1151,6 +1281,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  emojis-list@3.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -1269,6 +1401,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  home-assistant-js-websocket@6.1.1: {}
+
   home-assistant-js-websocket@9.6.0: {}
 
   ignore@5.3.2: {}
@@ -1281,6 +1415,13 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  intl-messageformat@9.13.0:
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.11.4
+      '@formatjs/fast-memoize': 1.2.1
+      '@formatjs/icu-messageformat-parser': 2.1.0
+      tslib: 2.8.1
 
   is-core-module@2.16.1:
     dependencies:
@@ -1321,15 +1462,31 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lit-element@3.3.3:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.0
+      '@lit/reactive-element': 1.6.3
+      lit-html: 2.8.0
+
   lit-element@4.2.2:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.5.0
       '@lit/reactive-element': 2.1.2
       lit-html: 3.3.2
 
+  lit-html@2.8.0:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
   lit-html@3.3.2:
     dependencies:
       '@types/trusted-types': 2.0.7
+
+  lit@2.8.0:
+    dependencies:
+      '@lit/reactive-element': 1.6.3
+      lit-element: 3.3.3
+      lit-html: 2.8.0
 
   lit@3.3.2:
     dependencies:
@@ -1406,6 +1563,10 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  rollup@2.79.2:
+    optionalDependencies:
+      fsevents: 2.3.3
+
   rollup@4.54.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -1459,6 +1620,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  superstruct@0.15.5: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -1486,6 +1649,19 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  typescript-eslint@8.51.0(eslint@9.39.2)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2)(typescript@5.9.3)
+      eslint: 9.39.2
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@4.9.5: {}
 
   typescript@5.9.3: {}
 

--- a/src/leaflet-loader.ts
+++ b/src/leaflet-loader.ts
@@ -1,0 +1,143 @@
+/**
+ * Leaflet Dynamic Loader
+ *
+ * Dynamically loads Leaflet.js and CSS from CDN with SRI verification.
+ * Uses a singleton pattern to prevent multiple loads when several cards
+ * are on the same page.
+ */
+
+// Note: The global L declaration is in leaflet-types.d.ts
+
+/** Leaflet version to load from CDN */
+const LEAFLET_VERSION = "1.9.4";
+
+/** CDN URLs for Leaflet assets */
+const LEAFLET_CSS_URL = `https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.css`;
+const LEAFLET_JS_URL = `https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.js`;
+
+/**
+ * SRI (Subresource Integrity) hashes for Leaflet 1.9.4
+ * These ensure the loaded files haven't been tampered with.
+ */
+const LEAFLET_CSS_INTEGRITY =
+  "sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=";
+const LEAFLET_JS_INTEGRITY =
+  "sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=";
+
+/** Loading state tracking */
+let leafletLoadPromise: Promise<typeof L> | null = null;
+let leafletLoaded = false;
+
+/**
+ * Injects a CSS stylesheet into the document head.
+ *
+ * @param url - The URL of the stylesheet
+ * @param integrity - SRI hash for verification
+ * @returns Promise that resolves when CSS is loaded
+ */
+function loadCSS(url: string, integrity: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Check if already loaded
+    const existingLink = document.querySelector(`link[href="${url}"]`);
+    if (existingLink) {
+      resolve();
+      return;
+    }
+
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = url;
+    link.integrity = integrity;
+    link.crossOrigin = "anonymous";
+
+    link.onload = () => resolve();
+    link.onerror = () =>
+      reject(new Error(`Failed to load Leaflet CSS from ${url}`));
+
+    document.head.appendChild(link);
+  });
+}
+
+/**
+ * Injects a JavaScript file into the document.
+ *
+ * @param url - The URL of the script
+ * @param integrity - SRI hash for verification
+ * @returns Promise that resolves when script is loaded
+ */
+function loadScript(url: string, integrity: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Check if Leaflet is already available
+    if (typeof window !== "undefined" && "L" in window) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = url;
+    script.integrity = integrity;
+    script.crossOrigin = "anonymous";
+    script.async = true;
+
+    script.onload = () => resolve();
+    script.onerror = () =>
+      reject(new Error(`Failed to load Leaflet JS from ${url}`));
+
+    document.head.appendChild(script);
+  });
+}
+
+/**
+ * Loads Leaflet library from CDN.
+ *
+ * Uses a singleton pattern - multiple calls will return the same promise,
+ * ensuring Leaflet is only loaded once even with multiple card instances.
+ *
+ * @returns Promise that resolves with the Leaflet L object
+ * @throws Error if Leaflet fails to load
+ */
+export async function loadLeaflet(): Promise<typeof L> {
+  // Return cached promise if already loading/loaded
+  if (leafletLoadPromise) {
+    return leafletLoadPromise;
+  }
+
+  // Return immediately if already loaded
+  if (leafletLoaded && typeof L !== "undefined") {
+    return L;
+  }
+
+  // Create loading promise
+  leafletLoadPromise = (async () => {
+    try {
+      // Load CSS first (map rendering depends on styles)
+      await loadCSS(LEAFLET_CSS_URL, LEAFLET_CSS_INTEGRITY);
+
+      // Then load JavaScript
+      await loadScript(LEAFLET_JS_URL, LEAFLET_JS_INTEGRITY);
+
+      // Verify Leaflet loaded correctly
+      if (typeof L === "undefined") {
+        throw new Error("Leaflet loaded but L is undefined");
+      }
+
+      leafletLoaded = true;
+      return L;
+    } catch (error) {
+      // Reset promise on failure to allow retry
+      leafletLoadPromise = null;
+      throw error;
+    }
+  })();
+
+  return leafletLoadPromise;
+}
+
+/**
+ * Checks if Leaflet is currently loaded.
+ *
+ * @returns true if Leaflet is available
+ */
+export function isLeafletLoaded(): boolean {
+  return leafletLoaded && typeof L !== "undefined";
+}

--- a/src/leaflet-types.d.ts
+++ b/src/leaflet-types.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Type declarations for dynamically loaded Leaflet.
+ *
+ * Since we load Leaflet via CDN script injection rather than ES module import,
+ * we need to declare the global L object that Leaflet creates on window.
+ */
+
+import type * as LeafletNamespace from "leaflet";
+
+declare global {
+  /**
+   * The Leaflet library global object.
+   * Available after loading via loadLeaflet() from leaflet-loader.ts
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const L: typeof LeafletNamespace;
+}
+
+export {};

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -20,6 +20,11 @@ export const styles = css`
     font-weight: 500;
   }
 
+  .map-wrapper {
+    position: relative;
+    width: 100%;
+  }
+
   .map-container {
     height: 400px;
     width: 100%;
@@ -30,6 +35,44 @@ export const styles = css`
     width: 100%;
     border-radius: 0 0 var(--ha-card-border-radius, 12px)
       var(--ha-card-border-radius, 12px);
+  }
+
+  /* Loading state */
+  .loading-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 400px;
+    gap: 16px;
+    color: var(--primary-text-color, #333);
+  }
+
+  .loading-text {
+    font-size: 14px;
+    opacity: 0.7;
+  }
+
+  /* Error state */
+  .error-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 400px;
+    gap: 16px;
+    color: var(--error-color, #cc0000);
+    padding: 16px;
+    text-align: center;
+  }
+
+  .error-container ha-icon {
+    --mdc-icon-size: 48px;
+  }
+
+  .error-text {
+    font-size: 14px;
+    max-width: 300px;
   }
 
   /* Australian Warning System legend */
@@ -52,5 +95,25 @@ export const styles = css`
     width: 16px;
     height: 16px;
     border-radius: 2px;
+  }
+
+  /* Leaflet controls styling to match HA theme */
+  .leaflet-control-zoom a {
+    background: var(--card-background-color, white) !important;
+    color: var(--primary-text-color, #333) !important;
+  }
+
+  .leaflet-control-zoom a:hover {
+    background: var(--secondary-background-color, #f5f5f5) !important;
+  }
+
+  .leaflet-control-attribution {
+    background: var(--card-background-color, rgba(255, 255, 255, 0.8)) !important;
+    color: var(--secondary-text-color, #666) !important;
+    font-size: 10px;
+  }
+
+  .leaflet-control-attribution a {
+    color: var(--primary-color, #03a9f4) !important;
   }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for ABC Emergency Map Card
  */
 
-import type { HomeAssistant, LovelaceCardConfig } from "custom-card-helpers";
+import type { LovelaceCardConfig } from "custom-card-helpers";
 
 export interface ABCEmergencyMapCardConfig extends LovelaceCardConfig {
   type: "custom:abc-emergency-map-card";


### PR DESCRIPTION
## Summary

Implements core Leaflet map setup with proper lifecycle management for the ABC Emergency Map Card.

Closes #2

### Changes
- Dynamic Leaflet 1.9.4 loading from CDN with SRI verification
- Singleton pattern prevents duplicate Leaflet loads across multiple cards
- Proper map lifecycle management (init, resize, cleanup)
- ResizeObserver for container size changes
- Loading and error states with retry functionality
- Uses Home Assistant location for initial map center
- ESLint 9 flat config with TypeScript support
- Documents Leaflet version choice in README

### Acceptance Criteria
- [x] Leaflet library dynamically loaded (avoid bundling large assets)
- [x] Map container properly sized within ha-card
- [x] Map initializes on firstUpdated lifecycle
- [x] Map properly resizes on container changes
- [x] Cleanup on disconnectedCallback
- [x] Error handling for failed Leaflet load

## Test Plan
- [ ] Verify map loads and displays OpenStreetMap tiles
- [ ] Verify map centers on HA configured location (or Australia fallback)
- [ ] Resize browser window and verify map adjusts properly
- [ ] Test error state by blocking CDN (shows error with retry button)
- [ ] Navigate away and back to verify cleanup/reinit works

---
Generated with [Claude Code](https://claude.com/claude-code)