### PR TITLE
feat(polygons): Add ABC Emergency GeoJSON polygon rendering

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -216,4 +216,36 @@ export const styles = css`
     align-items: center;
     justify-content: center;
   }
+
+  /* Incident popup styles */
+  .incident-popup {
+    font-size: 13px;
+    line-height: 1.4;
+    min-width: 180px;
+  }
+
+  .incident-popup-header {
+    margin-bottom: 4px;
+  }
+
+  .incident-popup-header strong {
+    color: var(--primary-text-color, #333);
+    font-size: 14px;
+  }
+
+  .incident-popup-body {
+    color: var(--secondary-text-color, #666);
+  }
+
+  .incident-popup-body small {
+    display: block;
+    margin-top: 4px;
+    line-height: 1.3;
+  }
+
+  .incident-alert-badge {
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
 `;


### PR DESCRIPTION
## Summary

Implements ABC Emergency GeoJSON polygon rendering with Australian Warning System colors.

### Changes
- Add `IncidentPolygonManager` class to render GeoJSON polygons from entity attributes
- Support both `geojson` and `geometry` attribute formats from ABC Emergency integration
- Apply Australian Warning System colors based on `alert_level`:
  - 🔴 **Extreme** (Emergency Warning) - Red `#cc0000`
  - 🟠 **Severe** (Watch and Act) - Orange `#ff6600`
  - 🟡 **Moderate** (Advice) - Yellow `#ffcc00`
  - 🔵 **Minor** (Information) - Blue `#3366cc`
- Create styled popups showing incident headline, alert badge, type, and description
- Integrate with BoundsManager for auto-fit functionality
- Add incident popup CSS styles for consistent theming
- Respect `show_warning_levels` config option to hide/show polygons

### Technical Details
- Extracts GeoJSON from `geojson` or `geometry` entity attributes
- Handles Polygon, MultiPolygon, and Point geometry types
- Smooth layer updates without flickering (clear and re-add pattern)
- Proper cleanup on disconnect

## Test Plan
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Production build succeeds
- [ ] Manual testing with ABC Emergency integration entities

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)