### PR TITLE
feat(animations): add pulse/glow effects for incident polygons

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -299,4 +299,73 @@ export const styles = css`
   .incident-popup-container .leaflet-popup-content-wrapper {
     padding: 0;
   }
+
+  /* Incident animation keyframes */
+  @keyframes incident-appear {
+    0% {
+      opacity: 0;
+      filter: drop-shadow(0 0 0 transparent);
+    }
+    30% {
+      opacity: 1;
+      filter: drop-shadow(0 0 12px var(--incident-glow-color, rgba(255, 102, 0, 0.8)));
+    }
+    100% {
+      opacity: 1;
+      filter: drop-shadow(0 0 0 transparent);
+    }
+  }
+
+  @keyframes incident-pulse {
+    0%, 100% {
+      filter: drop-shadow(0 0 0 transparent);
+    }
+    25% {
+      filter: drop-shadow(0 0 8px var(--incident-glow-color, rgba(255, 102, 0, 0.8)));
+    }
+    50% {
+      filter: drop-shadow(0 0 0 transparent);
+    }
+    75% {
+      filter: drop-shadow(0 0 8px var(--incident-glow-color, rgba(255, 102, 0, 0.8)));
+    }
+  }
+
+  @keyframes incident-glow-extreme {
+    0%, 100% {
+      filter: drop-shadow(0 0 4px rgba(204, 0, 0, 0.6));
+    }
+    50% {
+      filter: drop-shadow(0 0 12px rgba(204, 0, 0, 0.9));
+    }
+  }
+
+  /* Incident animation classes */
+  .incident-layer-new {
+    animation: incident-appear var(--incident-animation-duration, 2s) ease-out forwards;
+  }
+
+  .incident-layer-updated {
+    animation: incident-pulse var(--incident-animation-duration, 2s) ease-in-out;
+  }
+
+  .incident-layer-extreme {
+    animation: incident-glow-extreme 2s ease-in-out infinite;
+  }
+
+  /* Respect prefers-reduced-motion */
+  @media (prefers-reduced-motion: reduce) {
+    .incident-layer-new,
+    .incident-layer-updated,
+    .incident-layer-extreme {
+      animation: none !important;
+    }
+  }
+
+  /* Animation disabled via config */
+  .animations-disabled .incident-layer-new,
+  .animations-disabled .incident-layer-updated,
+  .animations-disabled .incident-layer-extreme {
+    animation: none !important;
+  }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,10 @@ export interface ABCEmergencyMapCardConfig extends LovelaceCardConfig {
   history_entities?: string[];
   /** Trail line weight in pixels (default: 3) */
   history_line_weight?: number;
+  /** Whether to enable incident animations (default: true) */
+  animations_enabled?: boolean;
+  /** Duration of pulse animation in milliseconds (default: 2000) */
+  animation_duration?: number;
 }
 
 export interface EmergencyIncident {
@@ -204,6 +208,12 @@ export const DEFAULT_HISTORY_LINE_WEIGHT = 3;
 
 /** Default hours to show for history trails */
 export const DEFAULT_HOURS_TO_SHOW = 24;
+
+/** Default animations enabled setting */
+export const DEFAULT_ANIMATIONS_ENABLED = true;
+
+/** Default animation duration in milliseconds */
+export const DEFAULT_ANIMATION_DURATION = 2000;
 
 /**
  * A single history point with timestamp and coordinates.


### PR DESCRIPTION
## Summary

Implements visual feedback animations for emergency incidents on the map:

- **New incident appear animation** - Fade-in with glow effect when new incidents are detected
- **Update pulse animation** - Double-pulse glow when incident data changes (alert level, headline, etc.)
- **Persistent extreme glow** - Continuous pulsing glow for emergency warning (extreme) alerts
- **CSS custom properties** - Per-alert-level glow colors using `--incident-glow-color`
- **Hash-based change detection** - Compares `alert_level|headline|alert_text|last_updated` to detect updates
- **Configuration options** - `animations_enabled` (default: true), `animation_duration` (default: 2000ms)
- **Accessibility** - Respects `prefers-reduced-motion` media query
- **Config disable** - `.animations-disabled` class for config-based animation control

## Test Plan

- [ ] Verify new incidents appear with fade-in glow animation
- [ ] Verify updated incidents pulse twice when data changes
- [ ] Verify extreme alert polygons have continuous pulsing glow
- [ ] Verify `animations_enabled: false` disables all animations
- [ ] Verify `animation_duration` customizes animation speed
- [ ] Verify animations respect `prefers-reduced-motion` preference
- [ ] Verify TypeScript compiles without errors
- [ ] Verify build succeeds

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)