### PR TITLE
feat(animations): add smooth geometry transitions for polygon updates

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,10 @@ export interface ABCEmergencyMapCardConfig extends LovelaceCardConfig {
   animations_enabled?: boolean;
   /** Duration of pulse animation in milliseconds (default: 2000) */
   animation_duration?: number;
+  /** Whether to enable smooth geometry transitions (default: true) */
+  geometry_transitions?: boolean;
+  /** Duration of geometry transition in milliseconds (default: 500) */
+  transition_duration?: number;
 }
 
 export interface EmergencyIncident {
@@ -214,6 +218,12 @@ export const DEFAULT_ANIMATIONS_ENABLED = true;
 
 /** Default animation duration in milliseconds */
 export const DEFAULT_ANIMATION_DURATION = 2000;
+
+/** Default geometry transitions enabled */
+export const DEFAULT_GEOMETRY_TRANSITIONS = true;
+
+/** Default geometry transition duration in milliseconds */
+export const DEFAULT_TRANSITION_DURATION = 500;
 
 /**
  * A single history point with timestamp and coordinates.


### PR DESCRIPTION
## Summary

Implements animated morphing between polygon geometries when incident boundaries change (e.g., fire perimeter expansion):

- **Linear interpolation** between coordinate arrays for smooth vertex movement
- **Resampling algorithm** to handle different vertex counts between old and new geometry
- **Multi-geometry support** for Polygon and MultiPolygon types
- **Ease-out cubic easing** for natural motion feel
- **requestAnimationFrame** for smooth 60fps animation performance
- **Configuration options**:
  - `geometry_transitions: true/false` (default: true)
  - `transition_duration: 500` (milliseconds)
- **Graceful fallbacks**:
  - Instant update for Point geometries
  - Instant update if geometry types don't match
  - Active transition cancellation on cleanup

## Technical Implementation

The algorithm works by:
1. Detecting geometry coordinate changes via hash comparison
2. Resampling both old and new coordinate arrays to the same length
3. Linearly interpolating each vertex position over the transition duration
4. Using requestAnimationFrame for frame-by-frame updates

## Test Plan

- [ ] Verify polygon vertices animate smoothly when geometry updates
- [ ] Verify MultiPolygon geometries transition correctly
- [ ] Verify `geometry_transitions: false` disables animation
- [ ] Verify `transition_duration` customizes animation speed
- [ ] Verify Point geometries update instantly (no animation)
- [ ] Verify mismatched geometry types switch at midpoint
- [ ] Verify active transitions are cancelled on cleanup
- [ ] Verify TypeScript compiles without errors
- [ ] Verify build succeeds

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)