### PR TITLE
feat(ui): add incident count badge to card header

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -15,9 +15,46 @@ export const styles = css`
   }
 
   .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     padding: 16px 16px 0;
     font-size: 1.2em;
     font-weight: 500;
+  }
+
+  .header-title {
+    flex: 1;
+  }
+
+  /* Incident count badge */
+  .incident-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 16px;
+    color: #ffffff;
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .incident-badge ha-icon {
+    --mdc-icon-size: 16px;
+  }
+
+  .badge-count {
+    font-weight: 700;
+  }
+
+  .badge-new {
+    font-size: 11px;
+    font-weight: 400;
+    opacity: 0.9;
+    margin-left: 4px;
+    padding-left: 6px;
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
   }
 
   .map-wrapper {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,12 @@ export interface ABCEmergencyMapCardConfig extends LovelaceCardConfig {
   geometry_transitions?: boolean;
   /** Duration of geometry transition in milliseconds (default: 500) */
   transition_duration?: number;
+  /** Whether to show incident count badge (default: true) */
+  show_badge?: boolean;
+  /** Whether to show new incident indicators (default: true) */
+  show_new_indicator?: boolean;
+  /** Badge position (default: "top-right") */
+  badge_position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
 }
 
 export interface EmergencyIncident {
@@ -224,6 +230,18 @@ export const DEFAULT_GEOMETRY_TRANSITIONS = true;
 
 /** Default geometry transition duration in milliseconds */
 export const DEFAULT_TRANSITION_DURATION = 500;
+
+/** Default show badge setting */
+export const DEFAULT_SHOW_BADGE = true;
+
+/** Default show new indicator setting */
+export const DEFAULT_SHOW_NEW_INDICATOR = true;
+
+/** Default badge position */
+export const DEFAULT_BADGE_POSITION = "top-right";
+
+/** Duration in ms for an incident to be considered "new" */
+export const NEW_INCIDENT_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * A single history point with timestamp and coordinates.


### PR DESCRIPTION
## Summary

Implements visual badge notification system for the card header:

- **Incident count badge** - Displays total number of active ABC Emergency incidents
- **Severity color coding** - Badge background color matches highest severity level
- **New indicator** - Shows "+N new" for incidents updated within 5 minutes
- **Configuration options**:
  - `show_badge: true/false` (default: true)
  - `show_new_indicator: true/false` (default: true)
  - `badge_position` (for future on-map positioning)

## Visual Design

```
┌────────────────────────────────────────┐
│ Emergency Map              🔴 3 +1 new │
│ ┌────────────────────────────────────┐ │
│ │                                    │ │
│ │          [Map Content]             │ │
│ │                                    │ │
│ └────────────────────────────────────┘ │
└────────────────────────────────────────┘
```

## Test Plan

- [ ] Verify badge appears when incidents exist
- [ ] Verify badge is hidden when no incidents
- [ ] Verify badge color matches highest severity
- [ ] Verify "+N new" appears for recent incidents (< 5 mins)
- [ ] Verify `show_badge: false` hides badge
- [ ] Verify `show_new_indicator: false` hides new count
- [ ] Verify TypeScript compiles without errors
- [ ] Verify build succeeds

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)