### PR TITLE
feat(theme): implement comprehensive theme support with auto-detection

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -12,6 +12,21 @@ export const styles = css`
   ha-card {
     height: 100%;
     overflow: hidden;
+    /* Theme-aware CSS custom properties for consistent styling */
+    --map-shadow-color: rgba(0, 0, 0, 0.15);
+    --map-border-color: var(--divider-color, rgba(0, 0, 0, 0.12));
+  }
+
+  /* Dark theme adjustments */
+  ha-card.theme-dark {
+    --map-shadow-color: rgba(0, 0, 0, 0.4);
+    --map-border-color: var(--divider-color, rgba(255, 255, 255, 0.12));
+  }
+
+  /* Light theme explicit styling (for clarity) */
+  ha-card.theme-light {
+    --map-shadow-color: rgba(0, 0, 0, 0.15);
+    --map-border-color: var(--divider-color, rgba(0, 0, 0, 0.12));
   }
 
   .card-header {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,18 @@ export interface TileProviderPreset {
   name: string;
 }
 
+/**
+ * Dark mode setting options.
+ * - "auto": Follows Home Assistant theme setting
+ * - "light": Always use light mode tiles and UI
+ * - "dark": Always use dark mode tiles and UI
+ * - boolean: Legacy support (true = dark, false = light)
+ */
+export type DarkModeSetting = "auto" | "light" | "dark" | boolean;
+
+/** Default dark mode setting */
+export const DEFAULT_DARK_MODE: DarkModeSetting = "auto";
+
 export interface ABCEmergencyMapCardConfig extends LovelaceCardConfig {
   type: "custom:abc-emergency-map-card";
   title?: string;
@@ -50,7 +62,7 @@ export interface ABCEmergencyMapCardConfig extends LovelaceCardConfig {
   entities?: string[];
   default_zoom?: number;
   hours_to_show?: number;
-  dark_mode?: boolean;
+  dark_mode?: DarkModeSetting;
   show_warning_levels?: boolean;
   /** Tile provider identifier or 'custom' for custom URL */
   tile_provider?: TileProviderId;


### PR DESCRIPTION
## Summary

Implements comprehensive theme support for the ABC Emergency Map Card with seamless Home Assistant theme integration.

### Theme Detection
- **Auto mode** (default): Automatically follows HA theme setting
- **Light mode**: Always use light map tiles and UI
- **Dark mode**: Always use dark map tiles and UI
- Legacy boolean values still supported for backward compatibility

### Theme Detection Methods
The auto mode uses multiple detection methods for maximum compatibility:
1. `hass.themes.darkMode` property (HA 2021.6+)
2. CSS `prefers-color-scheme: dark` media query
3. Theme name containing "dark"

### Real-time Theme Switching
- Listens for `settheme` and `theme-changed` window events
- Tile layer updates automatically when theme changes
- No page refresh required

### CSS Theme Integration
- Applies `theme-dark` or `theme-light` class to `ha-card`
- Defines theme-aware CSS custom properties:
  - `--map-shadow-color`
  - `--map-border-color`
- All UI elements use HA CSS variables for consistent styling

### Editor Updates
- Dark Mode toggle replaced with Theme Mode dropdown
- Options: "Auto (from Home Assistant)", "Always Light", "Always Dark"

## Test Plan

- [ ] Verify auto mode follows HA theme setting
- [ ] Verify light mode always uses light tiles
- [ ] Verify dark mode always uses dark tiles
- [ ] Verify real-time theme switching works
- [ ] Verify CartoDB dark tiles load in dark mode
- [ ] Verify editor dropdown shows correct selection
- [ ] Verify legacy boolean config values still work
- [ ] Verify TypeScript compiles without errors

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)