### PR TITLE
fix: render Point-only geometry entities as markers

### DIFF
--- a/src/incident-polygons.ts
+++ b/src/incident-polygons.ts
@@ -205,11 +205,22 @@ function createFeature(
 }
 
 /**
- * Checks if an entity has GeoJSON/polygon data that can be rendered.
+ * Checks if an entity has GeoJSON/polygon data that can be rendered as a polygon.
+ * Point-only geometry returns false since those are rendered as markers instead.
  */
 function hasPolygonData(entity: HassEntity): boolean {
   const attrs = entity.attributes;
-  return !!(attrs.geojson || attrs.geometry);
+  const geojson = attrs.geojson || attrs.geometry;
+  if (!geojson) return false;
+
+  // Check geometry type - only true polygon types should be rendered by polygon manager
+  // Point geometry is handled by the marker system instead
+  const geometryType = (geojson as { type?: string }).type ||
+    (attrs.geometry_type as string);
+
+  return geometryType === "Polygon" ||
+    geometryType === "MultiPolygon" ||
+    geometryType === "GeometryCollection";
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the critical bug where entities with Point-type geometry become invisible on the map.

## Problem

Entities with Point-only geometry (but no Polygon/MultiPolygon bounds) were completely invisible because:

1. **Marker filter** (`abc-emergency-map-card.ts:652-661`) checked for the *presence* of geometry, not the *type*
2. Point geometries were filtered OUT of marker entities (assumed to be "polygon entities")
3. **Polygon manager** couldn't render Point as a polygon layer meaningfully
4. **Result**: Entity was not rendered anywhere

## Solution

- Update marker filter to check geometry TYPE, not just presence
- Point geometries now render as styled markers (like entities without geometry)
- Only Polygon/MultiPolygon/GeometryCollection types are filtered to polygon rendering
- Update `hasPolygonData()` function to only return true for actual polygon types

## Changes

| File | Change |
|------|--------|
| `src/abc-emergency-map-card.ts` | Check geometry type in marker filter |
| `src/incident-polygons.ts` | Update `hasPolygonData()` to exclude Point type |

## Truth Table (After Fix)

| Geometry Type | Rendered As |
|--------------|-------------|
| No geometry | Marker ✓ |
| Point | Marker ✓ |
| Polygon | Polygon layer ✓ |
| MultiPolygon | Polygon layer ✓ |
| GeometryCollection | Polygon layer ✓ |

## Testing

1. Build passes: ✓
2. TypeScript check passes: ✓
3. ESLint passes: ✓

## Fixes

Closes #71

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)