### PR TITLE
Add unit tests for marker visibility features

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "typecheck": "tsc --noEmit",
-    "test": "pnpm run typecheck && pnpm run lint && pnpm run build"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:all": "pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
@@ -39,13 +42,16 @@
     "@types/leaflet": "^1.9.21",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
+    "@vitest/coverage-v8": "^4.0.16",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
+    "happy-dom": "^20.1.0",
     "prettier": "^3.4.0",
     "rollup": "^4.28.0",
     "tslib": "^2.8.0",
     "typescript": "^5.7.0",
-    "typescript-eslint": "^8.51.0"
+    "typescript-eslint": "^8.51.0",
+    "vitest": "^4.0.16"
   },
   "dependencies": {
     "custom-card-helpers": "^1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,12 +45,18 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.0.0
         version: 8.51.0(eslint@9.39.2)(typescript@5.9.3)
+      '@vitest/coverage-v8':
+        specifier: ^4.0.16
+        version: 4.0.16(vitest@4.0.16(@types/node@20.19.28)(happy-dom@20.1.0)(terser@5.44.1))
       eslint:
         specifier: ^9.0.0
         version: 9.39.2
       eslint-config-prettier:
         specifier: ^10.0.0
         version: 10.1.8(eslint@9.39.2)
+      happy-dom:
+        specifier: ^20.1.0
+        version: 20.1.0
       prettier:
         specifier: ^3.4.0
         version: 3.7.4
@@ -66,8 +72,188 @@ importers:
       typescript-eslint:
         specifier: ^8.51.0
         version: 8.51.0(eslint@9.39.2)(typescript@5.9.3)
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@types/node@20.19.28)(happy-dom@20.1.0)(terser@5.44.1)
 
 packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -326,6 +512,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -338,11 +533,20 @@ packages:
   '@types/leaflet@1.9.21':
     resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
+  '@types/node@20.19.28':
+    resolution: {integrity: sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.51.0':
     resolution: {integrity: sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==}
@@ -403,6 +607,44 @@ packages:
     resolution: {integrity: sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@4.0.16':
+    resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
+    peerDependencies:
+      '@vitest/browser': 4.0.16
+      vitest: 4.0.16
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.0.16':
+    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+
+  '@vitest/mocker@4.0.16':
+    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.16':
+    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+
+  '@vitest/runner@4.0.16':
+    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+
+  '@vitest/snapshot@4.0.16':
+    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
+
+  '@vitest/spy@4.0.16':
+    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
+
+  '@vitest/utils@4.0.16':
+    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -423,6 +665,13 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.10:
+    resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -438,6 +687,10 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -485,6 +738,14 @@ packages:
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -537,9 +798,16 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -590,6 +858,10 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  happy-dom@20.1.0:
+    resolution: {integrity: sha512-ebvqjBqzenBk2LjzNEAzoj7yhw7rW/R2/wVevMu6Mrq3MXtcI/RUz4+ozpcOcqVLEWPqLfg2v9EAU7fFXZUUJw==}
+    engines: {node: '>=20.0.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -603,6 +875,9 @@ packages:
 
   home-assistant-js-websocket@9.6.0:
     resolution: {integrity: sha512-TK8HWW6UjCsUdjIBQRB2sBbEya0VniOBFqFjgqSznJiB7YriNgN8jghyThxOkgxwrnt2eN6oWoZMCTSp1o7H+w==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -643,6 +918,25 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -695,6 +989,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -705,8 +1006,16 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -735,9 +1044,19 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -793,8 +1112,15 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -802,6 +1128,12 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -823,9 +1155,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   ts-api-utils@2.3.0:
     resolution: {integrity: sha512-6eg3Y9SF7SsAvGzRHQvvc1skDAhwI4YQ32ui1scxD1Ccr0G5qIIbUBT3pFTKX8kmWIQClHobtUdNuaBgwdfdWg==}
@@ -857,23 +1200,214 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.16:
+    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.16
+      '@vitest/browser-preview': 4.0.16
+      '@vitest/browser-webdriverio': 4.0.16
+      '@vitest/ui': 4.0.16
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2)':
     dependencies:
@@ -1102,6 +1636,15 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.54.0':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
@@ -1112,9 +1655,19 @@ snapshots:
     dependencies:
       '@types/geojson': 7946.0.16
 
+  '@types/node@20.19.28':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/resolve@1.20.2': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.28
 
   '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
@@ -1207,6 +1760,62 @@ snapshots:
       '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
 
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@20.19.28)(happy-dom@20.1.0)(terser@5.44.1))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.16
+      ast-v8-to-istanbul: 0.3.10
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.16(@types/node@20.19.28)(happy-dom@20.1.0)(terser@5.44.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@4.0.16':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@20.19.28)(terser@5.44.1))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@20.19.28)(terser@5.44.1)
+
+  '@vitest/pretty-format@4.0.16':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.16':
+    dependencies:
+      '@vitest/utils': 4.0.16
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.16': {}
+
+  '@vitest/utils@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      tinyrainbow: 3.0.3
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -1226,6 +1835,14 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.10:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
+
   balanced-match@1.0.2: {}
 
   brace-expansion@1.1.12:
@@ -1240,6 +1857,8 @@ snapshots:
   buffer-from@1.1.2: {}
 
   callsites@3.1.0: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -1283,6 +1902,37 @@ snapshots:
   deepmerge@4.3.1: {}
 
   emojis-list@3.0.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escape-string-regexp@4.0.0: {}
 
@@ -1356,7 +2006,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -1395,6 +2051,17 @@ snapshots:
 
   globals@14.0.0: {}
 
+  happy-dom@20.1.0:
+    dependencies:
+      '@types/node': 20.19.28
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   has-flag@4.0.0: {}
 
   hasown@2.0.2:
@@ -1404,6 +2071,8 @@ snapshots:
   home-assistant-js-websocket@6.1.1: {}
 
   home-assistant-js-websocket@9.6.0: {}
+
+  html-escaper@2.0.2: {}
 
   ignore@5.3.2: {}
 
@@ -1440,6 +2109,29 @@ snapshots:
       '@types/estree': 1.0.8
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -1504,6 +2196,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.1:
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -1514,7 +2216,11 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.11: {}
+
   natural-compare@1.4.0: {}
+
+  obug@2.1.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -1543,7 +2249,17 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
   picomatch@4.0.3: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -1609,7 +2325,11 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   smob@1.5.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -1617,6 +2337,10 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -1635,10 +2359,16 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   ts-api-utils@2.3.0(typescript@5.9.3):
     dependencies:
@@ -1665,14 +2395,76 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@6.21.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vite@7.3.1(@types/node@20.19.28)(terser@5.44.1):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.54.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.28
+      fsevents: 2.3.3
+      terser: 5.44.1
+
+  vitest@4.0.16(@types/node@20.19.28)(happy-dom@20.1.0)(terser@5.44.1):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@20.19.28)(terser@5.44.1))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@20.19.28)(terser@5.44.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.28
+      happy-dom: 20.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  ws@8.19.0: {}
 
   yocto-queue@0.1.0: {}

--- a/src/geometry-utils.test.ts
+++ b/src/geometry-utils.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for geometry-utils.ts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isPolygonGeometryType, getGeometryType } from "./geometry-utils";
+
+// Note: getPolygonExtentMeters requires Leaflet which is loaded at runtime
+// Those tests would require mocking Leaflet or running in an integration test
+
+describe("isPolygonGeometryType", () => {
+  describe("polygon types", () => {
+    it("should return true for Polygon", () => {
+      expect(isPolygonGeometryType("Polygon")).toBe(true);
+    });
+
+    it("should return true for MultiPolygon", () => {
+      expect(isPolygonGeometryType("MultiPolygon")).toBe(true);
+    });
+
+    it("should return true for GeometryCollection", () => {
+      expect(isPolygonGeometryType("GeometryCollection")).toBe(true);
+    });
+  });
+
+  describe("non-polygon types", () => {
+    it("should return false for Point", () => {
+      expect(isPolygonGeometryType("Point")).toBe(false);
+    });
+
+    it("should return false for LineString", () => {
+      expect(isPolygonGeometryType("LineString")).toBe(false);
+    });
+
+    it("should return false for MultiPoint", () => {
+      expect(isPolygonGeometryType("MultiPoint")).toBe(false);
+    });
+
+    it("should return false for MultiLineString", () => {
+      expect(isPolygonGeometryType("MultiLineString")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should return false for undefined", () => {
+      expect(isPolygonGeometryType(undefined)).toBe(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(isPolygonGeometryType("")).toBe(false);
+    });
+
+    it("should return false for lowercase polygon", () => {
+      // GeoJSON types are case-sensitive
+      expect(isPolygonGeometryType("polygon")).toBe(false);
+    });
+
+    it("should return false for unknown type", () => {
+      expect(isPolygonGeometryType("CustomType")).toBe(false);
+    });
+  });
+});
+
+describe("getGeometryType", () => {
+  describe("geojson attribute", () => {
+    it("should extract type from geojson attribute", () => {
+      const attrs = {
+        geojson: { type: "Polygon", coordinates: [] },
+      };
+
+      expect(getGeometryType(attrs)).toBe("Polygon");
+    });
+
+    it("should handle MultiPolygon type", () => {
+      const attrs = {
+        geojson: { type: "MultiPolygon", coordinates: [] },
+      };
+
+      expect(getGeometryType(attrs)).toBe("MultiPolygon");
+    });
+
+    it("should handle Point type", () => {
+      const attrs = {
+        geojson: { type: "Point", coordinates: [0, 0] },
+      };
+
+      expect(getGeometryType(attrs)).toBe("Point");
+    });
+  });
+
+  describe("geometry attribute", () => {
+    it("should extract type from geometry attribute when geojson is absent", () => {
+      const attrs = {
+        geometry: { type: "Polygon", coordinates: [] },
+      };
+
+      expect(getGeometryType(attrs)).toBe("Polygon");
+    });
+
+    it("should prefer geojson over geometry attribute", () => {
+      const attrs = {
+        geojson: { type: "Polygon", coordinates: [] },
+        geometry: { type: "Point", coordinates: [0, 0] },
+      };
+
+      expect(getGeometryType(attrs)).toBe("Polygon");
+    });
+  });
+
+  describe("geometry_type attribute fallback", () => {
+    it("should use geometry_type attribute when geojson has no type", () => {
+      const attrs = {
+        geojson: { coordinates: [] }, // No type property
+        geometry_type: "Polygon",
+      };
+
+      expect(getGeometryType(attrs)).toBe("Polygon");
+    });
+
+    it("should prefer geojson.type over geometry_type", () => {
+      const attrs = {
+        geojson: { type: "MultiPolygon", coordinates: [] },
+        geometry_type: "Polygon",
+      };
+
+      expect(getGeometryType(attrs)).toBe("MultiPolygon");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should return undefined for empty attributes", () => {
+      const attrs = {};
+
+      expect(getGeometryType(attrs)).toBeUndefined();
+    });
+
+    it("should return undefined when no geometry data present", () => {
+      const attrs = {
+        latitude: 0,
+        longitude: 0,
+      };
+
+      expect(getGeometryType(attrs)).toBeUndefined();
+    });
+
+    it("should handle null geojson", () => {
+      const attrs = {
+        geojson: null,
+      };
+
+      expect(getGeometryType(attrs)).toBeUndefined();
+    });
+  });
+});
+
+// Tests for getPolygonExtentMeters require Leaflet mocking.
+// These tests use vi.stubGlobal to mock the L object.
+
+describe("getPolygonExtentMeters (with Leaflet mock)", () => {
+  beforeEach(() => {
+    // Mock Leaflet using vi.stubGlobal
+    const mockBounds = {
+      isValid: vi.fn().mockReturnValue(true),
+      getNorthEast: vi.fn().mockReturnValue({ lat: -33.0, lng: 151.5 }),
+      getSouthWest: vi.fn().mockReturnValue({ lat: -34.0, lng: 150.5 }),
+    };
+
+    const mockLayer = {
+      getBounds: vi.fn().mockReturnValue(mockBounds),
+    };
+
+    const mockLatLng = {
+      distanceTo: vi.fn().mockReturnValue(111000), // ~111km per degree
+    };
+
+    vi.stubGlobal("L", {
+      geoJSON: vi.fn().mockReturnValue(mockLayer),
+      latLng: vi.fn().mockReturnValue(mockLatLng),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should return 0 for undefined input", async () => {
+    // Dynamic import to get fresh module with mocked L
+    const { getPolygonExtentMeters } = await import("./geometry-utils");
+    expect(getPolygonExtentMeters(undefined)).toBe(0);
+  });
+
+  it("should calculate extent for valid polygon", async () => {
+    const { getPolygonExtentMeters } = await import("./geometry-utils");
+
+    const polygon: GeoJSON.Polygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [150.5, -34.0],
+          [151.5, -34.0],
+          [151.5, -33.0],
+          [150.5, -33.0],
+          [150.5, -34.0],
+        ],
+      ],
+    };
+
+    const extent = getPolygonExtentMeters(polygon);
+
+    expect(L.geoJSON).toHaveBeenCalledWith(polygon);
+    expect(extent).toBeGreaterThan(0);
+  });
+
+  it("should return 0 for invalid bounds", async () => {
+    // Override mock to return invalid bounds
+    const mockBounds = {
+      isValid: vi.fn().mockReturnValue(false),
+    };
+
+    const mockLayer = {
+      getBounds: vi.fn().mockReturnValue(mockBounds),
+    };
+
+    vi.stubGlobal("L", {
+      geoJSON: vi.fn().mockReturnValue(mockLayer),
+      latLng: vi.fn(),
+    });
+
+    const { getPolygonExtentMeters } = await import("./geometry-utils");
+
+    const polygon: GeoJSON.Polygon = {
+      type: "Polygon",
+      coordinates: [],
+    };
+
+    expect(getPolygonExtentMeters(polygon)).toBe(0);
+  });
+
+  it("should return 0 and log warning on error", async () => {
+    // Override mock to throw error
+    vi.stubGlobal("L", {
+      geoJSON: vi.fn().mockImplementation(() => {
+        throw new Error("Invalid GeoJSON");
+      }),
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { getPolygonExtentMeters } = await import("./geometry-utils");
+
+    const polygon: GeoJSON.Polygon = {
+      type: "Polygon",
+      coordinates: [],
+    };
+
+    expect(getPolygonExtentMeters(polygon)).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "ABC Emergency Map: Failed to calculate polygon extent"
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/geometry-utils.ts
+++ b/src/geometry-utils.ts
@@ -1,0 +1,74 @@
+/**
+ * Geometry Utility Functions
+ *
+ * Pure utility functions for GeoJSON geometry calculations.
+ * These functions are designed to be easily testable.
+ */
+
+import type { LatLngBounds } from "leaflet";
+
+/**
+ * Calculates the maximum extent (width or height) of a GeoJSON geometry in meters.
+ * Uses Leaflet's geodetic distance calculation for accuracy.
+ *
+ * @param geojson - A GeoJSON geometry object (Polygon, MultiPolygon, GeometryCollection)
+ * @returns The maximum extent in meters, or 0 if the geometry is invalid/empty
+ */
+export function getPolygonExtentMeters(geojson: GeoJSON.GeoJSON | undefined): number {
+  if (!geojson) return 0;
+
+  try {
+    // Create a temporary GeoJSON layer to get bounds
+    const layer = L.geoJSON(geojson);
+    const bounds: LatLngBounds = layer.getBounds();
+
+    if (!bounds.isValid()) return 0;
+
+    const ne = bounds.getNorthEast();
+    const sw = bounds.getSouthWest();
+
+    // Calculate width and height in meters using Leaflet's geodetic distance
+    const width = L.latLng(ne.lat, sw.lng).distanceTo(ne);
+    const height = L.latLng(sw.lat, ne.lng).distanceTo(sw);
+
+    // Return the maximum dimension
+    return Math.max(width, height);
+  } catch {
+    console.warn("ABC Emergency Map: Failed to calculate polygon extent");
+    return 0;
+  }
+}
+
+/**
+ * Checks if a geometry type represents a polygon (not a point).
+ *
+ * @param geometryType - The GeoJSON geometry type string
+ * @returns True if the geometry is a polygon type
+ */
+export function isPolygonGeometryType(geometryType: string | undefined): boolean {
+  if (!geometryType) return false;
+  return (
+    geometryType === "Polygon" ||
+    geometryType === "MultiPolygon" ||
+    geometryType === "GeometryCollection"
+  );
+}
+
+/**
+ * Extracts the geometry type from entity attributes.
+ *
+ * @param attributes - Entity attributes object
+ * @returns The geometry type string or undefined
+ */
+export function getGeometryType(
+  attributes: Record<string, unknown>
+): string | undefined {
+  const geojson = attributes.geojson || attributes.geometry;
+  if (!geojson) return undefined;
+
+  return (
+    (geojson as { type?: string }).type ||
+    (attributes.geometry_type as string) ||
+    undefined
+  );
+}

--- a/src/incident-polygons.test.ts
+++ b/src/incident-polygons.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for incident-polygons.ts - hasPolygonData function
+ */
+
+import { describe, it, expect } from "vitest";
+import { hasPolygonData } from "./incident-polygons";
+import type { HassEntity } from "home-assistant-js-websocket";
+
+/**
+ * Helper to create a mock HassEntity with specific attributes
+ */
+function createMockEntity(
+  attributes: Record<string, unknown>
+): HassEntity {
+  return {
+    entity_id: "geo_location.test",
+    state: "active",
+    attributes: {
+      friendly_name: "Test Entity",
+      ...attributes,
+    },
+    last_changed: new Date().toISOString(),
+    last_updated: new Date().toISOString(),
+    context: {
+      id: "test",
+      parent_id: null,
+      user_id: null,
+    },
+  };
+}
+
+describe("hasPolygonData", () => {
+  describe("polygon geometry types", () => {
+    it("should return true for Polygon geometry in geojson attribute", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 1],
+              [0, 0],
+            ],
+          ],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(true);
+    });
+
+    it("should return true for MultiPolygon geometry", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "MultiPolygon",
+          coordinates: [
+            [
+              [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+                [0, 0],
+              ],
+            ],
+          ],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(true);
+    });
+
+    it("should return true for GeometryCollection", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "GeometryCollection",
+          geometries: [],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(true);
+    });
+
+    it("should return true for Polygon in geometry attribute", () => {
+      const entity = createMockEntity({
+        geometry: {
+          type: "Polygon",
+          coordinates: [],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(true);
+    });
+  });
+
+  describe("point geometry types", () => {
+    it("should return false for Point geometry", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "Point",
+          coordinates: [0, 0],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+
+    it("should return false for Point in geometry attribute", () => {
+      const entity = createMockEntity({
+        geometry: {
+          type: "Point",
+          coordinates: [0, 0],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+  });
+
+  describe("geometry_type attribute fallback", () => {
+    it("should use geometry_type when geojson has no type", () => {
+      const entity = createMockEntity({
+        geojson: { coordinates: [] },
+        geometry_type: "Polygon",
+      });
+
+      expect(hasPolygonData(entity)).toBe(true);
+    });
+
+    it("should return false when geometry_type is Point", () => {
+      const entity = createMockEntity({
+        geojson: { coordinates: [] },
+        geometry_type: "Point",
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+
+    it("should prefer geojson.type over geometry_type", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "Point",
+          coordinates: [0, 0],
+        },
+        geometry_type: "Polygon",
+      });
+
+      // Should use geojson.type (Point), not geometry_type (Polygon)
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+  });
+
+  describe("missing geometry", () => {
+    it("should return false when no geometry attributes present", () => {
+      const entity = createMockEntity({
+        latitude: 0,
+        longitude: 0,
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+
+    it("should return false when geojson is null", () => {
+      const entity = createMockEntity({
+        geojson: null,
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+
+    it("should return false when geojson is undefined", () => {
+      const entity = createMockEntity({
+        geojson: undefined,
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+
+    it("should return false when both geojson and geometry are empty objects", () => {
+      const entity = createMockEntity({
+        geojson: {},
+        geometry: {},
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+  });
+
+  describe("line geometry types", () => {
+    it("should return false for LineString geometry", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [1, 1],
+          ],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+
+    it("should return false for MultiLineString geometry", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "MultiLineString",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 1],
+            ],
+          ],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle geojson attribute preference over geometry", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "Polygon",
+          coordinates: [],
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [0, 0],
+        },
+      });
+
+      // Should use geojson (Polygon), not geometry (Point)
+      expect(hasPolygonData(entity)).toBe(true);
+    });
+
+    it("should handle unknown geometry types", () => {
+      const entity = createMockEntity({
+        geojson: {
+          type: "CustomType",
+          coordinates: [],
+        },
+      });
+
+      expect(hasPolygonData(entity)).toBe(false);
+    });
+  });
+});

--- a/src/incident-polygons.ts
+++ b/src/incident-polygons.ts
@@ -208,7 +208,7 @@ function createFeature(
  * Checks if an entity has GeoJSON/polygon data that can be rendered as a polygon.
  * Point-only geometry returns false since those are rendered as markers instead.
  */
-function hasPolygonData(entity: HassEntity): boolean {
+export function hasPolygonData(entity: HassEntity): boolean {
   const attrs = entity.attributes;
   const geojson = attrs.geojson || attrs.geometry;
   if (!geojson) return false;

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for types.ts - Configuration validation functions
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateVisibilityConfig, getAlertColor } from "./types";
+import type { ABCEmergencyMapCardConfig } from "./types";
+
+describe("validateVisibilityConfig", () => {
+  describe("hide_markers_for_polygons with show_warning_levels", () => {
+    it("should return warning when hide_markers_for_polygons is true but show_warning_levels is false", () => {
+      const config: Partial<ABCEmergencyMapCardConfig> = {
+        show_warning_levels: false,
+        hide_markers_for_polygons: true,
+      };
+
+      const warnings = validateVisibilityConfig(config);
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].id).toBe("hide-markers-no-effect");
+      expect(warnings[0].severity).toBe("warning");
+      expect(warnings[0].message).toContain("hide_markers_for_polygons");
+      expect(warnings[0].message).toContain("no effect");
+      expect(warnings[0].suggestion).toBeDefined();
+    });
+
+    it("should return no warnings when show_warning_levels is true", () => {
+      const config: Partial<ABCEmergencyMapCardConfig> = {
+        show_warning_levels: true,
+        hide_markers_for_polygons: true,
+      };
+
+      const warnings = validateVisibilityConfig(config);
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("should return no warnings when hide_markers_for_polygons is false", () => {
+      const config: Partial<ABCEmergencyMapCardConfig> = {
+        show_warning_levels: false,
+        hide_markers_for_polygons: false,
+      };
+
+      const warnings = validateVisibilityConfig(config);
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("should return no warnings when both options are undefined", () => {
+      const config: Partial<ABCEmergencyMapCardConfig> = {};
+
+      const warnings = validateVisibilityConfig(config);
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("should return no warnings when only show_warning_levels is set to false", () => {
+      const config: Partial<ABCEmergencyMapCardConfig> = {
+        show_warning_levels: false,
+      };
+
+      const warnings = validateVisibilityConfig(config);
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("should return no warnings when only hide_markers_for_polygons is set to true", () => {
+      const config: Partial<ABCEmergencyMapCardConfig> = {
+        hide_markers_for_polygons: true,
+      };
+
+      const warnings = validateVisibilityConfig(config);
+
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});
+
+describe("getAlertColor", () => {
+  describe("without configuration", () => {
+    it("should return default color for extreme level", () => {
+      expect(getAlertColor("extreme")).toBe("#cc0000");
+    });
+
+    it("should return default color for severe level", () => {
+      expect(getAlertColor("severe")).toBe("#ff6600");
+    });
+
+    it("should return default color for moderate level", () => {
+      expect(getAlertColor("moderate")).toBe("#ffcc00");
+    });
+
+    it("should return default color for minor level", () => {
+      expect(getAlertColor("minor")).toBe("#3366cc");
+    });
+
+    it("should return minor color for invalid level", () => {
+      expect(getAlertColor("invalid")).toBe("#3366cc");
+    });
+
+    it("should return minor color for empty string", () => {
+      expect(getAlertColor("")).toBe("#3366cc");
+    });
+  });
+
+  describe("with alert_colors config", () => {
+    it("should use custom color when provided", () => {
+      const config = {
+        alert_colors: {
+          extreme: "#ff0000",
+        },
+      };
+
+      expect(getAlertColor("extreme", config)).toBe("#ff0000");
+    });
+
+    it("should fall back to default for levels not overridden", () => {
+      const config = {
+        alert_colors: {
+          extreme: "#ff0000",
+        },
+      };
+
+      expect(getAlertColor("severe", config)).toBe("#ff6600");
+    });
+
+    it("should handle partial overrides", () => {
+      const config = {
+        alert_colors: {
+          extreme: "#aa0000",
+          minor: "#0000aa",
+        },
+      };
+
+      expect(getAlertColor("extreme", config)).toBe("#aa0000");
+      expect(getAlertColor("severe", config)).toBe("#ff6600"); // Default
+      expect(getAlertColor("minor", config)).toBe("#0000aa");
+    });
+  });
+
+  describe("with alert_color_preset config", () => {
+    it("should use us_nws preset colors", () => {
+      const config = {
+        alert_color_preset: "us_nws" as const,
+      };
+
+      expect(getAlertColor("minor", config)).toBe("#00bfff"); // Cyan
+    });
+
+    it("should use eu_meteo preset colors", () => {
+      const config = {
+        alert_color_preset: "eu_meteo" as const,
+      };
+
+      expect(getAlertColor("minor", config)).toBe("#33cc33"); // Green
+    });
+
+    it("should use high_contrast preset colors", () => {
+      const config = {
+        alert_color_preset: "high_contrast" as const,
+      };
+
+      expect(getAlertColor("extreme", config)).toBe("#990000"); // Darker red
+    });
+
+    it("should use australian preset by default", () => {
+      const config = {
+        alert_color_preset: "australian" as const,
+      };
+
+      expect(getAlertColor("minor", config)).toBe("#3366cc");
+    });
+  });
+
+  describe("preset with overrides", () => {
+    it("should allow alert_colors to override preset values", () => {
+      const config = {
+        alert_color_preset: "us_nws" as const,
+        alert_colors: {
+          minor: "#purple", // Override the cyan
+        },
+      };
+
+      expect(getAlertColor("minor", config)).toBe("#purple");
+      expect(getAlertColor("severe", config)).toBe("#ff6600"); // Preset value
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/editor.ts"],
+    },
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary

- Set up Vitest testing framework with happy-dom environment
- Added 62 comprehensive unit tests for visibility-related functions
- Refactored geometry utilities into a separate module for testability

## Changes

### Test Framework Setup
- Added Vitest, @vitest/coverage-v8, and happy-dom as dev dependencies
- Created `vitest.config.ts` with appropriate configuration
- Updated package.json with test scripts (`test`, `test:watch`, `test:coverage`, `test:all`)

### New Test Files
| File | Tests | Coverage |
|------|-------|----------|
| `src/types.test.ts` | 20 | validateVisibilityConfig, getAlertColor |
| `src/geometry-utils.test.ts` | 25 | isPolygonGeometryType, getGeometryType, getPolygonExtentMeters |
| `src/incident-polygons.test.ts` | 17 | hasPolygonData |

### Refactoring
- Created `src/geometry-utils.ts` with exported utility functions
- Exported `hasPolygonData()` from `src/incident-polygons.ts`
- Updated `src/abc-emergency-map-card.ts` to use new geometry-utils module

## Test Coverage

All tests cover the marker visibility feature epic (#67):
- Configuration validation and warning generation
- Geometry type detection (Polygon, MultiPolygon, Point, etc.)
- Polygon extent calculation with Leaflet mocking
- Alert color resolution with presets and overrides

## Test Plan

- [x] All 62 unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint linting passes
- [x] Production build succeeds

## Related Issues

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)